### PR TITLE
Implement generic button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
 import MenuOptions from "@/components/homepage/MenuOptions";
-import { Button } from "@/components/ui/button";
 import { ArrowBigDownDash, Banknote, MailIcon, Wallet } from "lucide-react";
 
 export default function Home() {
@@ -31,12 +30,6 @@ export default function Home() {
       <h1 className="text-5xl font-bold mt-16 mb-8 text-seniorBankDarkBlue">
         Handlinger
       </h1>
-
-      <div className="flex gap-4 my-4">
-        <Button variant="destructive">Avbryt</Button>
-        <Button variant="default">Bekreft</Button>
-        <Button chevron variant="default">Gå tilbake til hovedside</Button>
-      </div>
 
       <div className="flex flex-col items-center gap-8">
         <div className="grid grid-cols-1 md:grid-cols-2 max-w-7xl w-full gap-8">

--- a/components/homepage/MenuOptions.tsx
+++ b/components/homepage/MenuOptions.tsx
@@ -18,7 +18,7 @@ const MenuOptions = ({ title, description, icon }: Props) => {
           <p className="text-gray-600">{description}</p>
         </div>
       </div>
-      <ChevronRight />
+      <ChevronRight className="size-16 group-hover:translate-x-1 transition-transform duration-200" />
     </div>
   );
 };

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -28,7 +28,7 @@ const buttonVariants = cva(
     defaultVariants: {
       variant: "default",
       size: "default",
-    }
+    },
   }
 )
 


### PR DESCRIPTION
Adds a generic button component which can be used across the project. There are two color variants: `default` and `destructive`, and optionally a "chevron" (right arrow icon, see image below) which can be enabled by passing `chevron={true}` (or just `chevron`) to the component. 

<img width="978" alt="Example buttons using component" src="https://github.com/user-attachments/assets/97fafc02-0170-4361-a514-167824158268" />

Closes #27 